### PR TITLE
FID implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 */__pycache__/
 __pycache__/*
 data
+generated
 GANJax.egg-info

--- a/apps/evals.py
+++ b/apps/evals.py
@@ -1,0 +1,25 @@
+import argparse 
+import pickle
+
+from utils.evals import frechet_inception_distance
+
+
+if __name__ == '__main__':
+    
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--eval', type=str, help='Evaluation method')
+    parser.add_argument('--dataset_path', type=str, help='Real dataset on which to compute the evaluation metric')
+    parser.add_argument('--generated_path', type=str, help='Generated dataset on which to compute the evaluation metric')
+    args = parser.parse_args()
+
+    with open(args.generated_path, 'rb') as generated:
+        images = pickle.load(generated)
+    
+
+    if args.eval == 'FID':
+        print('Evaluating FID score...')
+        assert 'dataset_path' in args
+        images_eval = (images + 1)/2 # rescale values between 0 and 1 for evaluation
+
+        score = frechet_inception_distance(images_eval, args.dataset_path, img_size=(256,256))
+        print('FID score : ' + str(score))

--- a/apps/test.py
+++ b/apps/test.py
@@ -1,14 +1,13 @@
 import os
+import argparse
+import pickle
 
 from jax import random
 import haiku as hk
 
-import argparse
-
 from gan.dcgan import DCGAN as GAN
 from utils.save_and_load import load_jax_model
 from utils.plot_img import plot_tensor_images
-from utils.evals import frechet_inception_distance
 
 gan = GAN()
 trainer = gan.Trainer()
@@ -25,6 +24,9 @@ def generate(zseed, config, n_samples=1, is_training=False):
 
 if __name__ == '__main__':
     from matplotlib import pyplot as plt
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--save_images_path', type=str, help='Path to save generated images')
+    args = parser.parse_args()
     model_path = 'pre_trained/CelebA-64/dcgan'
     seed = 0
     zseed = 0
@@ -42,22 +44,10 @@ if __name__ == '__main__':
                                config=config,
                                n_samples=num_images[0]*num_images[1],
                                is_training=False)
-
-
-
-    ### evaluation
-    parser = argparse.ArgumentParser()
-    parser.add_argument('--eval', type=str, help='Evaluation method')
-    parser.add_argument('--dataset_path', type=str, help='Real dataset on which to compute the evaluation metric')
-    args = parser.parse_args()
-
-    if args.eval == 'FID':
-        print('Evaluating FID score...')
-        assert 'dataset_path' in args
-        images_eval = (images + 1)/2 # rescale values between 0 and 1 for evaluation
-
-        score = frechet_inception_distance(images_eval, args.dataset_path, img_size=(256,256))
-        print('FID score : ' + str(score))
+    
+    if args.save_images_path is not None:
+        with open(args.save_images_path, 'wb') as save_images:
+            pickle.dump(images, save_images)
 
 
     plot_tensor_images(images, num_images=num_images, cmap=cmap)

--- a/apps/test.py
+++ b/apps/test.py
@@ -1,11 +1,14 @@
 import os
 
-import haiku as hk
 from jax import random
+import haiku as hk
+
+import argparse
 
 from gan.dcgan import DCGAN as GAN
 from utils.save_and_load import load_jax_model
 from utils.plot_img import plot_tensor_images
+from utils.evals import frechet_inception_distance
 
 gan = GAN()
 trainer = gan.Trainer()
@@ -40,5 +43,23 @@ if __name__ == '__main__':
                                n_samples=num_images[0]*num_images[1],
                                is_training=False)
 
+
+
+    ### evaluation
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--eval', type=str, help='Evaluation method')
+    parser.add_argument('--dataset_path', type=str, help='Real dataset on which to compute the evaluation metric')
+    args = parser.parse_args()
+
+    if args.eval == 'FID':
+        print('Evaluating FID score...')
+        assert 'dataset_path' in args
+        images_eval = (images + 1)/2 # rescale values between 0 and 1 for evaluation
+
+        score = frechet_inception_distance(images_eval, args.dataset_path, img_size=(256,256))
+        print('FID score : ' + str(score))
+
+
     plot_tensor_images(images, num_images=num_images, cmap=cmap)
     plt.show()
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-dm-haiku>=0.01
+dm-haiku>=0.0.5
 matplotlib>=3.5.0
 optax>=0.1.0
+jax-fid

--- a/utils/evals.py
+++ b/utils/evals.py
@@ -1,0 +1,61 @@
+import jax
+from jax import jit, numpy as jnp
+import numpy as np
+from tqdm import tqdm
+import os
+from PIL import Image
+
+import functools
+from jax_fid import fid, inception
+
+def compute_statistics_from_image(images, params, apply_fn, batch_size=1, img_size=None):
+    if type(images) == str:
+        imgs = []
+        for f in os.listdir(images)[:100]:
+            img = Image.open(os.path.join(images, f))
+            img = jnp.array(img) / 255.0
+            if img_size is not None:
+                img = jax.image.resize(img, shape=(img_size[0], img_size[1], img.shape[2]), method='bilinear', antialias=False)
+            imgs.append(img)
+        images = jnp.array(imgs)
+
+    else:
+        imgs = []
+        for img in images:
+            #img = jnp.array(img) / 255.0
+            if img_size is not None:
+                img = jax.image.resize(img, shape=(img_size[0], img_size[1], img.shape[2]), method='bilinear', antialias=False)
+            imgs.append(img)
+        images = jnp.array(imgs)
+    
+    num_batches = int(np.ceil(images.shape[0] / batch_size))
+    act = []
+    for i in tqdm(range(num_batches)):
+        x = images[i * batch_size:i * batch_size + batch_size]
+        x = 2 * x - 1
+
+        pred = apply_fn(params, jax.lax.stop_gradient(x))
+        act.append(pred.squeeze(axis=1).squeeze(axis=1))
+    act = jnp.concatenate(act, axis=0)
+
+    mu = np.mean(act, axis=0)
+    sigma = np.cov(act, rowvar=False)
+    return mu, sigma
+
+def frechet_inception_distance(images1, images2, batch_size=50, img_size=None, key=0):
+
+    rng = jax.random.PRNGKey(key)
+    model = inception.InceptionV3(pretrained=True)
+    params = model.init(rng, jnp.ones((1, 256, 256, 3)))
+
+    apply_fn = jax.jit(functools.partial(model.apply, train=False))
+
+    print('Computing statistics for dataset 1...')
+    mu1,sigma1 = compute_statistics_from_image(images1, params, apply_fn, batch_size, img_size)
+    print('Computing statistics for dataset 2...')
+    mu2,sigma2 = compute_statistics_from_image(images2, params, apply_fn, batch_size, img_size)
+
+    fid_score = fid.compute_frechet_distance(mu1, mu2, sigma1, sigma2, eps=1e-6)
+    
+    return fid_score
+

--- a/utils/evals.py
+++ b/utils/evals.py
@@ -11,7 +11,7 @@ from jax_fid import fid, inception
 def compute_statistics_from_image(images, params, apply_fn, batch_size=1, img_size=None):
     if type(images) == str:
         imgs = []
-        for f in os.listdir(images)[:100]:
+        for f in os.listdir(images):
             img = Image.open(os.path.join(images, f))
             img = jnp.array(img) / 255.0
             if img_size is not None:


### PR DESCRIPTION
This is an implementation of Frechet Inception Distance (FID).

To use it : 

1. save generated images, for instance using apps/test.py script (by specifying a save_images_path argument to save your .pkl file of generated images)
2. launch the evaluation script with following command : `python apps/evals.py --eval FID --dataset_path data/CelebA/img_align_celeba --generated_path ./generated/images.pkl`
with dataset_path the path towards your directory of real images, and generated_path your path towards you generated images.